### PR TITLE
License details: Just say what you mean, it's better.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ Find comprehensive documentation here: TBD
 
 ## License
 
-See the included LICENSE.txt file.
+Apache 2.0 
+
+See the included LICENSE file for details.
 
 **[Back to top](#table-of-contents)**
 


### PR DESCRIPTION
0. Just say what the license is: that way it works as the website http://snomedin5minutes.org/, where the phrase 'included LICENSE file' is nonsensical
1. LICENSE.txt is not the name of the included file. Definitely don't say the license is included in a file that is not included
2. x