### PR TITLE
updated Python3 example to use HTTPS API endpoint instead of HTTP, wh…

### DIFF
--- a/python3-examples/examples.py
+++ b/python3-examples/examples.py
@@ -2,7 +2,7 @@ from urllib.request import urlopen
 from urllib.parse import quote
 import json
 
-baseUrl = 'http://browser.ihtsdotools.org/api/v1/snomed/'
+baseUrl = 'https://browser.ihtsdotools.org/api/v1/snomed/'
 edition = 'en-edition'
 version = 'v20180131'
 


### PR DESCRIPTION
Updated Python3 example to use HTTPS API endpoint instead of HTTP, which was returning either 400 Bad Request or 301 Moved Permanently.
