### PR TITLE
Add User-Agent to header in Python3 examples to prevent IP blocked me…

### DIFF
--- a/python3-examples/examples.py
+++ b/python3-examples/examples.py
@@ -1,4 +1,4 @@
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
 from urllib.parse import quote
 import json
 
@@ -6,10 +6,16 @@ baseUrl = 'https://browser.ihtsdotools.org/snowstorm/snomed-ct'
 edition = 'MAIN'
 version = '2019-07-31'
 
+def urlopen_with_header(url):
+    # adds User-Agent header otherwise urlopen on its own gets an IP blocked response
+    req = Request(url)
+    req.add_header('User-Agent','Python3')
+    return urlopen(req)
+
 #Prints fsn of a concept
 def getConceptById(id):
     url = baseUrl + '/browser/' + edition + '/' + version + '/concepts/' + id
-    response = urlopen(url).read()
+    response = urlopen_with_header(url).read()
     data = json.loads(response.decode('utf-8'))
 
     print (data['fsn']['term'])
@@ -17,7 +23,7 @@ def getConceptById(id):
 #Prints description by id
 def getDescriptionById(id):
     url = baseUrl + '/' + edition + '/' + version + '/descriptions/' + id
-    response = urlopen(url).read()
+    response = urlopen_with_header(url).read()
     data = json.loads(response.decode('utf-8'))
 
     print (data['term'])
@@ -25,7 +31,7 @@ def getDescriptionById(id):
 #Prints number of concepts with descriptions containing the search term
 def getConceptsByString(searchTerm):
     url = baseUrl + '/browser/' + edition + '/' + version + '/concepts?term=' + quote(searchTerm) + '&activeFilter=true&offset=0&limit=50'
-    response = urlopen(url).read()
+    response = urlopen_with_header(url).read()
     data = json.loads(response.decode('utf-8'))
 
     print (data['total'])
@@ -33,7 +39,7 @@ def getConceptsByString(searchTerm):
 #Prints number of descriptions containing the search term with a specific semantic tag
 def getDescriptionsByStringFromProcedure(searchTerm, semanticTag):
     url = baseUrl + '/browser/' + edition + '/' + version + '/descriptions?term=' + quote(searchTerm) + '&conceptActive=true&semanticTag=' + quote(semanticTag) + '&groupByConcept=false&searchMode=STANDARD&offset=0&limit=50'
-    response = urlopen(url).read()
+    response = urlopen_with_header(url).read()
     data = json.loads(response.decode('utf-8'))
 
     print (data['totalElements'])


### PR DESCRIPTION
The file python3-examples/example.py was  generating  this error

>CYGWIN> python3 examples.py
Traceback (most recent call last):
  File "/cygdrive/c/Users/jeremy/GIT/SNOMED-in-5-minutes/python3-examples/examples.py", line 41, in <module>
    getConceptById('109152007')
  File "/cygdrive/c/Users/jeremy/GIT/SNOMED-in-5-minutes/python3-examples/examples.py", line 13, in getConceptById
    data = json.loads(response.decode('utf-8'))
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

I traced it first to the fact that the response received was not valid json, but was an html page saying my IP was blocked.

As access via web browser still worked, I tried curl and that also worked.

So I checked the request header curl was sending and tried setting User-Agent in the header python was sending and that seemed to cure it.

I have added a function "url_open_with_header" which replaces the calls to the plain "urlopen" in the main body.

The output is now:

>CYGWIN> python3 examples.py
Bilirubin test kit (physical object)
Methylphenyltetrahydropyridine (substance)
471023
864



